### PR TITLE
Update openapi-schema-to-json-schema 3.2.0 -> 5.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         run: nix develop -c shellcheck -x test/*.bats
 
       - name: Shellcheck src
-        run: nix develop -c shellcheck -x src/*.sh
+        run: nix develop -c shellcheck src/*.sh
 
       - name: Run tests
         run: nix develop -c bats test

--- a/crd2jsonschema.nix
+++ b/crd2jsonschema.nix
@@ -13,7 +13,7 @@ in
 pkgs.buildNpmPackage
 {
     name              = "crd2jsonschema";
-    version           = "1.0.0";
+    version           = "1.0.1";
     src               = ./.;
     npmDepsHash       = "sha256-gRcvPyZZ1kdR4ig1rNBwNMP5k0PkJcevZVgpFIq/wPI=";
     nativeBuildInputs = with pkgs; [ makeBinaryWrapper esbuild ];

--- a/crd2jsonschema.nix
+++ b/crd2jsonschema.nix
@@ -15,7 +15,7 @@ pkgs.buildNpmPackage
     name              = "crd2jsonschema";
     version           = "1.0.1";
     src               = ./.;
-    npmDepsHash       = "sha256-gRcvPyZZ1kdR4ig1rNBwNMP5k0PkJcevZVgpFIq/wPI=";
+    npmDepsHash       = "sha256-lHaBVkSWr4qyHWb6rLF9iV8WW59XCxHvIGYMjrm0lIc=";
     nativeBuildInputs = with pkgs; [ makeBinaryWrapper esbuild ];
     postPatch         = 
     ''
@@ -27,7 +27,7 @@ pkgs.buildNpmPackage
     ''
         runHook preInstall
         install -Dm755 ./src/crd2jsonschema.sh $out/bin/crd2jsonschema
-        install -Dm755 ./dist/oas3tojsonschema4 $out/bin/oas3tojsonschema4
+        install -Dm755 ./dist/oas3tojsonschema4 $out/libexec/oas3tojsonschema4
         runHook postInstall
     '';
     nativeInstallCheckInputs = with pkgs;
@@ -49,7 +49,7 @@ pkgs.buildNpmPackage
     postFixup =
     ''
         wrapProgram $out/bin/crd2jsonschema \
-            --prefix PATH : "${pkgs.lib.makeBinPath runtimeDeps}:$out/bin"
+            --prefix PATH : "${pkgs.lib.makeBinPath runtimeDeps}:$out/libexec"
     '';
 
     passthru.runtimeDeps = runtimeDeps;

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -37,12 +37,15 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1678901627,
-        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -53,15 +56,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1679295821,
-        "narHash": "sha256-S8Q9IxSpKajcLPvrH1XqEpWckGiRatNUKrvZW6cmzK8=",
+        "lastModified": 1697723726,
+        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61d8fdca02b4647be8d38a94c6f53a7cf072d717",
+        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -72,6 +76,21 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
     description               = "crd2jsonschema-dev-shell";
     inputs.flake-utils.url    = "github:numtide/flake-utils";
-    inputs.nixpkgs.url        = "github:NixOS/nixpkgs";
+    inputs.nixpkgs.url        = "github:NixOS/nixpkgs/nixos-unstable";
     inputs.ci-flake-lib       =
     {
         url                        = "github:tricktron/ci-flake-lib";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,330 @@
 {
     "name": "oas3tojsonschema4",
-    "version": "3.2.0",
+    "version": "5.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "oas3tojsonschema4",
-            "version": "3.2.0",
+            "version": "5.1.0",
             "dependencies": {
-                "@openapi-contrib/openapi-schema-to-json-schema": "^3.2.0"
+                "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0"
             },
             "bin": {
                 "oas3tojsonschema4": "dist/oas3tojsonschema4"
             }
         },
+        "node_modules/@fastify/busboy": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
+            "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@openapi-contrib/openapi-schema-to-json-schema": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-3.2.0.tgz",
-            "integrity": "sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@openapi-contrib/openapi-schema-to-json-schema/-/openapi-schema-to-json-schema-5.1.0.tgz",
+            "integrity": "sha512-MJnq+CxD8JAufiJoa8RK6D/8P45MEBe0teUi30TNoHRrI6MZRNgetK2Y2IfDXWGLTHMopb1d9GHonqlV2Yvztg==",
             "dependencies": {
-                "fast-deep-equal": "^3.1.3"
+                "@types/json-schema": "^7.0.12",
+                "@types/lodash": "^4.14.195",
+                "@types/node": "^20.4.1",
+                "fast-deep-equal": "^3.1.3",
+                "lodash": "^4.17.21",
+                "openapi-typescript": "^5.4.1",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "openapi-schema-to-json-schema": "dist/bin.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.14",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
+            "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw=="
+        },
+        "node_modules/@types/lodash": {
+            "version": "4.14.200",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.200.tgz",
+            "integrity": "sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q=="
+        },
+        "node_modules/@types/node": {
+            "version": "20.8.7",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+            "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+            "dependencies": {
+                "undici-types": "~5.25.1"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dependencies": {
+                "color-name": "~1.1.4"
+            },
+            "engines": {
+                "node": ">=7.0.0"
+            }
+        },
+        "node_modules/color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "node_modules/get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "engines": {
+                "node": "6.* || 8.* || >= 10.*"
+            }
+        },
+        "node_modules/globalyzer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+            "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+        },
+        "node_modules/globrex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+            "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/js-yaml": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "dependencies": {
+                "argparse": "^2.0.1"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
+        "node_modules/mime": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+            "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/openapi-typescript": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-5.4.1.tgz",
+            "integrity": "sha512-AGB2QiZPz4rE7zIwV3dRHtoUC/CWHhUjuzGXvtmMQN2AFV8xCTLKcZUHLcdPQmt/83i22nRE7+TxXOXkK+gf4Q==",
+            "dependencies": {
+                "js-yaml": "^4.1.0",
+                "mime": "^3.0.0",
+                "prettier": "^2.6.2",
+                "tiny-glob": "^0.2.9",
+                "undici": "^5.4.0",
+                "yargs-parser": "^21.0.1"
+            },
+            "bin": {
+                "openapi-typescript": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">= 14.0.0"
+            }
+        },
+        "node_modules/prettier": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tiny-glob": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+            "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+            "dependencies": {
+                "globalyzer": "0.1.0",
+                "globrex": "^0.1.2"
+            }
+        },
+        "node_modules/undici": {
+            "version": "5.26.4",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.4.tgz",
+            "integrity": "sha512-OG+QOf0fTLtazL9P9X7yqWxQ+Z0395Wk6DSkyTxtaq3wQEjIroVe7Y4asCX/vcCxYpNGMnwz8F0qbRYUoaQVMw==",
+            "dependencies": {
+                "@fastify/busboy": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.0"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "5.25.3",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+            "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
+        },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/y18n": {
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+            "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "engines": {
+                "node": ">=12"
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
     "name": "oas3tojsonschema4",
-    "version": "3.2.0",
+    "version": "5.1.0",
     "bin": "./dist/oas3tojsonschema4",
     "dependencies": {
-        "@openapi-contrib/openapi-schema-to-json-schema": "^3.2.0"
+        "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0"
     },
     "scripts": {
         "build": "esbuild src/oas3tojsonschema4.js --bundle --outfile=dist/oas3tojsonschema4 --platform=node"

--- a/src/crd2jsonschema.sh
+++ b/src/crd2jsonschema.sh
@@ -86,7 +86,9 @@ function convert_crd_openapiv3_schema_to_jsonschema()
 {
     local crd
     crd="$1"
-    get_openapi_v3_schema "$crd" | convert_to_strict_json | convert_to_jsonschema4
+    local crd_schema
+    crd_schema="$(get_openapi_v3_schema "$crd")" || exit 1
+    echo "$crd_schema" | convert_to_strict_json | convert_to_jsonschema4
 }
 
 function create_all_jsonschema()
@@ -168,7 +170,7 @@ function main()
     fi
 }
 
-CRD2JSONSCHEMA_VERSION="1.0.0"
+CRD2JSONSCHEMA_VERSION="1.0.1"
 export CRD2JSONSCHEMA_VERSION
 
 if [ "${BASH_SOURCE[0]}" -ef "$0" ]

--- a/src/oas3tojsonschema4.js
+++ b/src/oas3tojsonschema4.js
@@ -1,12 +1,15 @@
 #!/usr/bin/env node
-
-const toJsonSchemaDraft4 = require("@openapi-contrib/openapi-schema-to-json-schema");
-const fs                 = require('fs');
+const fs                                                = require('fs');
+const { openapiSchemaToJsonSchema: toJsonSchemaDraft4 } = 
+    require("@openapi-contrib/openapi-schema-to-json-schema");
 
 try
 {
     const openapiV3Schema    = fs.readFileSync(0, 'utf-8');
-    const jsonSchemaDraft4   = toJsonSchemaDraft4(JSON.parse(openapiV3Schema.toString()));
+    const jsonSchemaDraft4   = toJsonSchemaDraft4
+    (
+        JSON.parse(openapiV3Schema.toString())
+    );
     console.log(JSON.stringify(jsonSchemaDraft4, null, 4));
     process.exit();
 

--- a/test/crd2jsonschema-test.bats
+++ b/test/crd2jsonschema-test.bats
@@ -5,7 +5,7 @@ setup() {
     bats_load_library bats-assert
     bats_load_library bats-file
     PROJECT_ROOT="$( cd "$( dirname "$BATS_TEST_FILENAME" )/.." >/dev/null 2>&1 && pwd )"
-    PATH="$PATH:$PROJECT_ROOT/dist"
+    PATH="$PROJECT_ROOT/dist:$PATH"
     TEST_TEMP_DIR="$(temp_make)"
     export BATSLIB_TEMP_PRESERVE=0
     export BATSLIB_TEMP_PRESERVE_ON_FAILURE=0
@@ -171,10 +171,7 @@ crd2jsonschema -a -o ./output ./crds/*.yml"
     crd_without_openapi_v3_schema="$PROJECT_ROOT/test/fixtures/bitnami-sealedsecret-without-openapiv3schema.yml"
     run "$PROJECT_ROOT"/src/crd2jsonschema.sh "$crd_without_openapi_v3_schema"
     assert_failure
-    assert_output "OpenAPI V3 schema not found. Is $crd_without_openapi_v3_schema a valid CRD?
-{
-    \"\$schema\": \"http://json-schema.org/draft-04/schema#\"
-}"
+    assert_output "OpenAPI V3 schema not found. Is $crd_without_openapi_v3_schema a valid CRD?"
 }
 
 @test "should convert single OpenAPI V3 YAML CRD file to JSON schema draft 4" {


### PR DESCRIPTION
## Improvements

- Updates flake
- Update openapi-schema-to-json-schema 3.2.0 -> 5.1.0
- Do not expose the oas3tojsonschema4 binary of the nix package to end-users.