### PR TITLE
Include CRD Group in Filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Examples:
 # convert a single CRD file and print to stdout
 crd2jsonschema your-crd.yml
 
-# convert a single CRD from a URL and write as kind_version.json to output dir 
+# convert a single CRD from a URL and write as kind_group_version.json to output dir 
 crd2jsonschema -o output-dir https://example.com/your-crd.yml
 
-# convert multiple CRDs, write kind_version.json files to output dir and
+# convert multiple CRDs, write kind_group_version.json files to output dir and
 # create all.json with all references to schemas
 crd2jsonschema -a -o ./output your-crd1.yml your-crd2.yml
 crd2jsonschema -a -o ./output ./crds/*.yml
@@ -42,7 +42,7 @@ crd2jsonschema -a -o ./output ./crds/*.yml
 ```bash
 # convert a single CRD and write to output dir
 docker run --rm -v $(pwd):/app ghcr.io/tricktron/crd2jsonschema -o output your-crd.yaml
-# convert multiple CRDs, write kind_version.json files to output dir and
+# convert multiple CRDs, write kind_group_version.json files to output dir and
 # create all.json with all references to schemas
 docker run --rm -v $(pwd):/app ghcr.io/tricktron/crd2jsonschema -a -o output crds/*.crd.yml
 ```

--- a/crd2jsonschema.nix
+++ b/crd2jsonschema.nix
@@ -13,7 +13,7 @@ in
 pkgs.buildNpmPackage
 {
     name              = "crd2jsonschema";
-    version           = "1.0.1";
+    version           = "1.0.2";
     src               = ./.;
     npmDepsHash       = "sha256-lHaBVkSWr4qyHWb6rLF9iV8WW59XCxHvIGYMjrm0lIc=";
     nativeBuildInputs = with pkgs; [ makeBinaryWrapper esbuild ];

--- a/flake.nix
+++ b/flake.nix
@@ -84,9 +84,9 @@
                                 https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/1f3e4021e27bc92f9881984a2348fe49aaa23727/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
                             docker run -v "$(pwd)":/app ${name}:${version} -a -o out \
                                 test/fixtures/*.crd.yml
-                            cat out/route_v1.json
+                            cat out/route_route.openshift.io_v1.json
                             cat out/all.json
-                            rm out/route_v1.json
+                            rm out/route_route.openshift.io_v1.json
                             rm out/all.json
                         '';
                     }}/bin/dockerIntegrationTest.sh";

--- a/src/crd2jsonschema.sh
+++ b/src/crd2jsonschema.sh
@@ -57,6 +57,14 @@ function get_crd_version()
         { echo ".spec.versions[0].name not found. Is $crd a valid CRD?" >&2; exit 1; }
 }
 
+function get_crd_group()
+{
+    local crd
+    crd="$1"
+    yq -e '.spec.group' "$crd" 2>/dev/null || \
+        { echo ".spec.group not found. Is $crd a valid CRD?" >&2; exit 1; }
+}
+
 function get_jsonschema_file_name()
 {   
     local crd
@@ -65,7 +73,9 @@ function get_jsonschema_file_name()
     crd_kind="$(get_crd_kind "$crd")" || exit 1
     local crd_version
     crd_version="$(get_crd_version "$crd")" || exit 1
-    echo "${crd_kind}_${crd_version}.json"
+    local crd_group
+    crd_group="$(get_crd_group "$crd")" || exit 1
+    echo "${crd_kind}_${crd_group}_${crd_version}.json"
 }
 
 function convert_to_strict_json()

--- a/src/crd2jsonschema.sh
+++ b/src/crd2jsonschema.sh
@@ -23,10 +23,10 @@ Examples:
 # convert a single CRD file and print to stdout
 crd2jsonschema your-crd.yml
 
-# convert a single CRD from a URL and write as kind_version.json to output dir 
+# convert a single CRD from a URL and write as kind_group_version.json to output dir 
 crd2jsonschema -o output-dir https://example.com/your-crd.yml
 
-# convert multiple CRDs, write kind_version.json files to output dir and
+# convert multiple CRDs, write kind_group_version.json files to output dir and
 # create all.json with all references to schemas
 crd2jsonschema -a -o ./output your-crd1.yml your-crd2.yml
 crd2jsonschema -a -o ./output ./crds/*.yml

--- a/src/crd2jsonschema.sh
+++ b/src/crd2jsonschema.sh
@@ -180,7 +180,7 @@ function main()
     fi
 }
 
-CRD2JSONSCHEMA_VERSION="1.0.1"
+CRD2JSONSCHEMA_VERSION="1.0.2"
 export CRD2JSONSCHEMA_VERSION
 
 if [ "${BASH_SOURCE[0]}" -ef "$0" ]

--- a/test/crd2jsonschema-test.bats
+++ b/test/crd2jsonschema-test.bats
@@ -44,10 +44,10 @@ Examples:
 # convert a single CRD file and print to stdout
 crd2jsonschema your-crd.yml
 
-# convert a single CRD from a URL and write as kind_version.json to output dir 
+# convert a single CRD from a URL and write as kind_group_version.json to output dir 
 crd2jsonschema -o output-dir https://example.com/your-crd.yml
 
-# convert multiple CRDs, write kind_version.json files to output dir and
+# convert multiple CRDs, write kind_group_version.json files to output dir and
 # create all.json with all references to schemas
 crd2jsonschema -a -o ./output your-crd1.yml your-crd2.yml
 crd2jsonschema -a -o ./output ./crds/*.yml"
@@ -78,10 +78,10 @@ Examples:
 # convert a single CRD file and print to stdout
 crd2jsonschema your-crd.yml
 
-# convert a single CRD from a URL and write as kind_version.json to output dir 
+# convert a single CRD from a URL and write as kind_group_version.json to output dir 
 crd2jsonschema -o output-dir https://example.com/your-crd.yml
 
-# convert multiple CRDs, write kind_version.json files to output dir and
+# convert multiple CRDs, write kind_group_version.json files to output dir and
 # create all.json with all references to schemas
 crd2jsonschema -a -o ./output your-crd1.yml your-crd2.yml
 crd2jsonschema -a -o ./output ./crds/*.yml"
@@ -108,10 +108,10 @@ Examples:
 # convert a single CRD file and print to stdout
 crd2jsonschema your-crd.yml
 
-# convert a single CRD from a URL and write as kind_version.json to output dir 
+# convert a single CRD from a URL and write as kind_group_version.json to output dir 
 crd2jsonschema -o output-dir https://example.com/your-crd.yml
 
-# convert multiple CRDs, write kind_version.json files to output dir and
+# convert multiple CRDs, write kind_group_version.json files to output dir and
 # create all.json with all references to schemas
 crd2jsonschema -a -o ./output your-crd1.yml your-crd2.yml
 crd2jsonschema -a -o ./output ./crds/*.yml"
@@ -138,13 +138,13 @@ crd2jsonschema -a -o ./output ./crds/*.yml"
     assert_output "$(cat "$PROJECT_ROOT"/test/fixtures/expected-openshift-route-jsonschema4.json)"
 }
 
-@test "should create kind_version.json file name from CRD metadata" {
+@test "should create kind_group_version.json file name from CRD metadata" {
     . "$PROJECT_ROOT"/src/crd2jsonschema.sh
 
     run get_jsonschema_file_name \
         "$PROJECT_ROOT/test/fixtures/openshift-route-v1.crd.yml"
 
-    assert_output "route_v1.json"
+    assert_output "route_route.openshift.io_v1.json"
 }
 
 @test "should exit if crd has no names.singular metadata" {
@@ -185,10 +185,10 @@ crd2jsonschema -a -o ./output ./crds/*.yml"
     run "$PROJECT_ROOT"/src/crd2jsonschema.sh -o "$TEST_TEMP_DIR" \
         "$PROJECT_ROOT"/test/fixtures/openshift-route-v1.crd.yml
 
-    assert_file_exist "$TEST_TEMP_DIR"/route_v1.json
+    assert_file_exist "$TEST_TEMP_DIR"/route_route.openshift.io_v1.json
     assert_file_not_exist "$TEST_TEMP_DIR"/all.json
     
-    run cat "$TEST_TEMP_DIR"/route_v1.json
+    run cat "$TEST_TEMP_DIR"/route_route.openshift.io_v1.json
     assert_output "$(cat "$PROJECT_ROOT"/test/fixtures/expected-openshift-route-jsonschema4.json)"
 }
 
@@ -223,13 +223,13 @@ Output directory does not exist: $TEST_TEMP_DIR/non-existing-dir"
         "$PROJECT_ROOT"/test/fixtures/openshift-route-v1.crd.yml \
         "$PROJECT_ROOT"/test/fixtures/bitnami-sealedsecret-v1alpha1.crd.yml
 
-    assert_file_exist "$TEST_TEMP_DIR"/route_v1.json
-    assert_file_exist "$TEST_TEMP_DIR"/sealedsecret_v1alpha1.json
+    assert_file_exist "$TEST_TEMP_DIR"/route_route.openshift.io_v1.json
+    assert_file_exist "$TEST_TEMP_DIR"/sealedsecret_bitnami.com_v1alpha1.json
     assert_file_not_exist "$TEST_TEMP_DIR"/all.json
     
-    run cat "$TEST_TEMP_DIR"/route_v1.json
+    run cat "$TEST_TEMP_DIR"/route_route.openshift.io_v1.json
     assert_output "$(cat "$PROJECT_ROOT"/test/fixtures/expected-openshift-route-jsonschema4.json)"
-    run cat "$TEST_TEMP_DIR"/sealedsecret_v1alpha1.json
+    run cat "$TEST_TEMP_DIR"/sealedsecret_bitnami.com_v1alpha1.json
     assert_output "$(cat "$PROJECT_ROOT"/test/fixtures/expected-bitnami-sealedsecret-jsonschema4.json)"
 }
 
@@ -241,7 +241,7 @@ Output directory does not exist: $TEST_TEMP_DIR/non-existing-dir"
     
     run cat "$TEST_TEMP_DIR"/all.json
     # shellcheck disable=SC2016
-    assert_output "$(yq -o json -I 4 -n '{"oneOf": [{"$ref": "sealedsecret_v1alpha1.json"}]}')"
+    assert_output "$(yq -o json -I 4 -n '{"oneOf": [{"$ref": "sealedsecret_bitnami.com_v1alpha1.json"}]}')"
 }
 
 @test "should create all.json with multiple references given -a option" {
@@ -249,8 +249,8 @@ Output directory does not exist: $TEST_TEMP_DIR/non-existing-dir"
         "$PROJECT_ROOT"/test/fixtures/bitnami-sealedsecret-v1alpha1.crd.yml \
         "$PROJECT_ROOT"/test/fixtures/openshift-route-v1.crd.yml
 
-    assert_file_exist "$TEST_TEMP_DIR"/route_v1.json
-    assert_file_exist "$TEST_TEMP_DIR"/sealedsecret_v1alpha1.json
+    assert_file_exist "$TEST_TEMP_DIR"/route_route.openshift.io_v1.json
+    assert_file_exist "$TEST_TEMP_DIR"/sealedsecret_bitnami.com_v1alpha1.json
     assert_file_exist "$TEST_TEMP_DIR"/all.json
     
     run cat "$TEST_TEMP_DIR"/all.json
@@ -261,9 +261,9 @@ Output directory does not exist: $TEST_TEMP_DIR/non-existing-dir"
     run "$PROJECT_ROOT"/src/crd2jsonschema.sh -o "$TEST_TEMP_DIR" \
         "$PROJECT_ROOT"/test/fixtures/openshift-ingresscontroller-v1.crd.yml
 
-    assert_file_exist "$TEST_TEMP_DIR"/ingresscontroller_v1.json
+    assert_file_exist "$TEST_TEMP_DIR"/ingresscontroller_operator.openshift.io_v1.json
     assert_file_not_exist "$TEST_TEMP_DIR"/all.json
 
-    run cat "$TEST_TEMP_DIR"/ingresscontroller_v1.json
+    run cat "$TEST_TEMP_DIR"/ingresscontroller_operator.openshift.io_v1.json
     assert_output "$(cat "$PROJECT_ROOT"/test/fixtures/expected-openshift-ingresscontroller-v1-jsonschema4.json)"
 }

--- a/test/fixtures/expected-multiple-all.json
+++ b/test/fixtures/expected-multiple-all.json
@@ -1,10 +1,10 @@
 {
     "oneOf": [
         {
-            "$ref": "sealedsecret_v1alpha1.json"
+            "$ref": "sealedsecret_bitnami.com_v1alpha1.json"
         },
         {
-            "$ref": "route_v1.json"
+            "$ref": "route_route.openshift.io_v1.json"
         }
     ]
 }


### PR DESCRIPTION
This avoids conflicts between CRDs which have the same short name but are coming from a different group (e.g. `Project/config.openshift.io/v1` vs. `Project/project.openshift.io/v1`)