### PR TITLE
Add Non Strict Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Convert Kubernetes Custom Resource Definitions (CRDs) OpenAPI V3.0 schemas to
 JSON schema draft 4. CRDs can be specified as a file path or as a URL.
 
 Options:
-  -o path   Output directory for JSON schema files
-  -a        Create all.json which references individual files
-  -v        Print the version of crd2jsonschema
-  -h        Print this help
+  -o path     Output directory for JSON schema files
+  -a          Create all.json which references individual files
+  -v          Print the version of crd2jsonschema
+  -h          Print this help
+  --no-strict Disables the default strict mode which reports unknown properties as errors
 
 Examples:
 

--- a/crd2jsonschema.nix
+++ b/crd2jsonschema.nix
@@ -13,7 +13,7 @@ in
 pkgs.buildNpmPackage
 {
     name              = "crd2jsonschema";
-    version           = "1.0.5";
+    version           = "1.1.0";
     src               = ./.;
     npmDepsHash       = "sha256-a3aS73p6fBSQQIl3RhiAeMnGqTPaFzA2ulhBUG6TMEM=";
     nativeBuildInputs = with pkgs; [ makeBinaryWrapper esbuild ];

--- a/src/crd2jsonschema.sh
+++ b/src/crd2jsonschema.sh
@@ -205,7 +205,7 @@ function main()
     fi
 }
 
-CRD2JSONSCHEMA_VERSION="1.0.5"
+CRD2JSONSCHEMA_VERSION="1.1.0"
 export CRD2JSONSCHEMA_VERSION
 
 if [ "${BASH_SOURCE[0]}" -ef "$0" ]

--- a/tests/acceptance/crd2jsonschema_test.sh
+++ b/tests/acceptance/crd2jsonschema_test.sh
@@ -66,6 +66,16 @@ function test_should_convert_single_OpenAPI_V3_YAML_CRD_file_to_JSON_schema_draf
     assert_same "$expected_json_schema" "$json_schema"
 }
 
+function test_should_convert_single_OpenAPI_V3_YAML_CRD_file_to_non_strict_JSON_schema_draft_4_given_-no-strict_flag()
+{
+    local expected_json_schema json_schema
+    expected_json_schema=$(cat "$ROOT_DIR/tests/fixtures/expected-openshift-route-jsonschema4-non-strict.json")
+
+    json_schema=$($SCRIPT --no-strict "$ROOT_DIR/tests/fixtures/openshift-route-v1.crd.yml")
+
+    assert_same "$expected_json_schema" "$json_schema"
+}
+
 function test_should_convert_single_OpenAPI_V3_YAML_CRD_to_JSON_schema_and_write_to_file_in_given_output_directory()
 {
     $SCRIPT -o "$TEMP_DIR" "$ROOT_DIR/tests/fixtures/openshift-route-v1.crd.yml"

--- a/tests/fixtures/expected-openshift-route-jsonschema4-non-strict.json
+++ b/tests/fixtures/expected-openshift-route-jsonschema4-non-strict.json
@@ -1,0 +1,221 @@
+{
+    "description": "A route allows developers to expose services through an HTTP(S) aware load balancing and proxy layer via a public DNS entry. The route may further specify TLS options and a certificate, or specify a public CNAME that the router should also accept for HTTP and HTTPS traffic. An administrator typically configures their router to be visible outside the cluster firewall, and may also add additional security, caching, or traffic controls on the service content. Routers usually talk directly to the service endpoints. \n Once a route is created, the `host` field may not be changed. Generally, routers use the oldest route with a given host when resolving conflicts. \n Routers are subject to additional customization and may support additional controls via the annotations field. \n Because administrators may configure multiple routers, the route status field is used to return information to clients about the names and states of the route under each router. If a client chooses a duplicate name, for instance, the route status conditions are used to indicate the route cannot be chosen. \n To enable HTTP/2 ALPN on a route it requires a custom (non-wildcard) certificate. This prevents connection coalescing by clients, notably web browsers. We do not support HTTP/2 ALPN on routes that use the default certificate because of the risk of connection re-use/coalescing. Routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend. \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "type": "object",
+    "required": [
+        "spec"
+    ],
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "description": "spec is the desired state of the route",
+            "type": "object",
+            "required": [
+                "to"
+            ],
+            "properties": {
+                "alternateBackends": {
+                    "description": "alternateBackends allows up to 3 additional backends to be assigned to the route. Only the Service kind is allowed, and it will be defaulted to Service. Use the weight field in RouteTargetReference object to specify relative preference.",
+                    "type": "array",
+                    "items": {
+                        "description": "RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service' kind is allowed. Use 'weight' field to emphasize one over others.",
+                        "type": "object",
+                        "required": [
+                            "kind",
+                            "name"
+                        ],
+                        "properties": {
+                            "kind": {
+                                "description": "The kind of target that the route is referring to. Currently, only 'Service' is allowed",
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name of the service/target that is being referred to. e.g. name of the service",
+                                "type": "string"
+                            },
+                            "weight": {
+                                "description": "weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.",
+                                "type": "integer",
+                                "format": "int32",
+                                "minimum": -2147483648,
+                                "maximum": 2147483647
+                            }
+                        }
+                    }
+                },
+                "host": {
+                    "description": "host is an alias/DNS that points to the service. Optional. If not specified a route name will typically be automatically chosen. Must follow DNS952 subdomain conventions.",
+                    "type": "string"
+                },
+                "path": {
+                    "description": "path that the router watches for, to route traffic for to the service. Optional",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "If specified, the port to be used by the router. Most routers will use all endpoints exposed by the service by default - set this value to instruct routers which port to use.",
+                    "type": "object",
+                    "required": [
+                        "targetPort"
+                    ],
+                    "properties": {
+                        "targetPort": {
+                            "description": "The target port on pods selected by the service this route points to. If this is a string, it will be looked up as a named port in the target endpoints port list. Required",
+                            "anyOf": [
+                                {
+                                    "type": "integer"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ],
+                            "x-kubernetes-int-or-string": true
+                        }
+                    }
+                },
+                "subdomain": {
+                    "description": "subdomain is a DNS subdomain that is requested within the ingress controller's domain (as a subdomain). If host is set this field is ignored. An ingress controller may choose to ignore this suggested name, in which case the controller will report the assigned name in the status.ingress array or refuse to admit the route. If this value is set and the server does not support this field host will be populated automatically. Otherwise host is left empty. The field may have multiple parts separated by a dot, but not all ingress controllers may honor the request. This field may not be changed after creation except by a user with the update routes/custom-host permission. \n Example: subdomain `frontend` automatically receives the router subdomain `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.",
+                    "type": "string"
+                },
+                "tls": {
+                    "description": "The tls field provides the ability to configure certificates and termination for the route.",
+                    "type": "object",
+                    "required": [
+                        "termination"
+                    ],
+                    "properties": {
+                        "caCertificate": {
+                            "description": "caCertificate provides the cert authority certificate contents",
+                            "type": "string"
+                        },
+                        "certificate": {
+                            "description": "certificate provides certificate contents. This should be a single serving certificate, not a certificate chain. Do not include a CA certificate.",
+                            "type": "string"
+                        },
+                        "destinationCACertificate": {
+                            "description": "destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt termination this file should be provided in order to have routers use it for health checks on the secure connection. If this field is not specified, the router may provide its own destination CA and perform hostname validation using the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically verify.",
+                            "type": "string"
+                        },
+                        "insecureEdgeTerminationPolicy": {
+                            "description": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While each router may make its own decisions on which ports to expose, this is normally port 80. \n * Allow - traffic is sent to the server on the insecure port (default) * Disable - no traffic is allowed on the insecure port. * Redirect - clients are redirected to the secure port.",
+                            "type": "string"
+                        },
+                        "key": {
+                            "description": "key provides key file contents",
+                            "type": "string"
+                        },
+                        "termination": {
+                            "description": "termination indicates termination type. \n * edge - TLS termination is done by the router and http is used to communicate with the backend (default) * passthrough - Traffic is sent straight to the destination without the router providing TLS termination * reencrypt - TLS termination is done by the router and https is used to communicate with the backend",
+                            "type": "string"
+                        }
+                    }
+                },
+                "to": {
+                    "description": "to is an object the route should use as the primary backend. Only the Service kind is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100) is set to zero, no traffic will be sent to this backend.",
+                    "type": "object",
+                    "required": [
+                        "kind",
+                        "name"
+                    ],
+                    "properties": {
+                        "kind": {
+                            "description": "The kind of target that the route is referring to. Currently, only 'Service' is allowed",
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "name of the service/target that is being referred to. e.g. name of the service",
+                            "type": "string"
+                        },
+                        "weight": {
+                            "description": "weight as an integer between 0 and 256, default 100, that specifies the target's relative weight against other target reference objects. 0 suppresses requests to this backend.",
+                            "type": "integer",
+                            "format": "int32",
+                            "minimum": -2147483648,
+                            "maximum": 2147483647
+                        }
+                    }
+                },
+                "wildcardPolicy": {
+                    "description": "Wildcard policy if any for the route. Currently only 'Subdomain' or 'None' is allowed.",
+                    "type": "string"
+                }
+            }
+        },
+        "status": {
+            "description": "status is the current state of the route",
+            "type": "object",
+            "properties": {
+                "ingress": {
+                    "description": "ingress describes the places where the route may be exposed. The list of ingress points may contain duplicate Host or RouterName values. Routes are considered live once they are `Ready`",
+                    "type": "array",
+                    "items": {
+                        "description": "RouteIngress holds information about the places where a route is exposed.",
+                        "type": "object",
+                        "properties": {
+                            "conditions": {
+                                "description": "Conditions is the state of the route, may be empty.",
+                                "type": "array",
+                                "items": {
+                                    "description": "RouteIngressCondition contains details for the current condition of this route on a particular router.",
+                                    "type": "object",
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "properties": {
+                                        "lastTransitionTime": {
+                                            "description": "RFC 3339 date and time when this condition last transitioned",
+                                            "type": "string",
+                                            "format": "date-time"
+                                        },
+                                        "message": {
+                                            "description": "Human readable message indicating details about last transition.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "(brief) reason for the condition's last transition, and is usually a machine and human readable constant",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status is the status of the condition. Can be True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type is the type of the condition. Currently only Admitted.",
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "host": {
+                                "description": "Host is the host string under which the route is exposed; this value is required",
+                                "type": "string"
+                            },
+                            "routerCanonicalHostname": {
+                                "description": "CanonicalHostname is the external host name for the router that can be used as a CNAME for the host requested for this route. This value is optional and may not be set in all cases.",
+                                "type": "string"
+                            },
+                            "routerName": {
+                                "description": "Name is a name chosen by the router to identify itself; this value is required",
+                                "type": "string"
+                            },
+                            "wildcardPolicy": {
+                                "description": "Wildcard policy is the wildcard policy that was allowed where this route is exposed.",
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}


### PR DESCRIPTION
Adds a long option `--no-strict` which disables the strict conversion and thus allows unknown properties in the schemas.