### PR TITLE
Fix: Only Set Additional Properties to false on Object Types

### DIFF
--- a/crd2jsonschema.nix
+++ b/crd2jsonschema.nix
@@ -13,7 +13,7 @@ in
 pkgs.buildNpmPackage
 {
     name              = "crd2jsonschema";
-    version           = "1.1.0";
+    version           = "1.1.1";
     src               = ./.;
     npmDepsHash       = "sha256-a3aS73p6fBSQQIl3RhiAeMnGqTPaFzA2ulhBUG6TMEM=";
     nativeBuildInputs = with pkgs; [ makeBinaryWrapper esbuild ];

--- a/flake.nix
+++ b/flake.nix
@@ -85,9 +85,9 @@
                             docker run ${name}:${version} \
                                 https://raw.githubusercontent.com/bitnami-labs/sealed-secrets/1f3e4021e27bc92f9881984a2348fe49aaa23727/helm/sealed-secrets/crds/bitnami.com_sealedsecrets.yaml
                             docker run -v "$(pwd)":/app ${name}:${version} -a -o out \
-                                tests/fixtures/*.crd.yml
+                                tests/fixtures/openshift-v4.18-route-v1.crd.yml
                             bashunit --assert files_equals \
-                                tests/fixtures/expected-openshift-route-jsonschema4.json \
+                                tests/fixtures/expected-openshift-v4.18-route-jsonschema4.json \
                                 out/route.openshift.io/route_v1.json
                             cat out/all.json
                         '';

--- a/src/crd2jsonschema.sh
+++ b/src/crd2jsonschema.sh
@@ -80,7 +80,7 @@ function get_jsonschema_file_name()
 function convert_to_strict_json()
 {
     yq -e -o json -I 4 '
-        with(.. | select(has("properties")) |
+        with(.. | select(has("properties")) | select(.type == "object") |
         select(has("additionalProperties") | not);
             .additionalProperties = false)
     ' 2>/dev/null

--- a/src/crd2jsonschema.sh
+++ b/src/crd2jsonschema.sh
@@ -205,7 +205,7 @@ function main()
     fi
 }
 
-CRD2JSONSCHEMA_VERSION="1.1.0"
+CRD2JSONSCHEMA_VERSION="1.1.1"
 export CRD2JSONSCHEMA_VERSION
 
 if [ "${BASH_SOURCE[0]}" -ef "$0" ]

--- a/tests/acceptance/crd2jsonschema_test.sh
+++ b/tests/acceptance/crd2jsonschema_test.sh
@@ -66,6 +66,16 @@ function test_should_convert_single_OpenAPI_V3_YAML_CRD_file_to_JSON_schema_draf
     assert_same "$expected_json_schema" "$json_schema"
 }
 
+function test_should_convert_complex_single_OpenAPI_V3_YAML_CRD_file_to_JSON_schema_draft_4_and_only_make_object_properties_strict()
+{
+    local expected_json_schema json_schema
+    expected_json_schema=$(cat "$ROOT_DIR/tests/fixtures/expected-openshift-v4.18-route-jsonschema4.json")
+
+    json_schema=$($SCRIPT "$ROOT_DIR/tests/fixtures/openshift-v4.18-route-v1.crd.yml")
+
+    assert_same "$expected_json_schema" "$json_schema"
+}
+
 function test_should_convert_single_OpenAPI_V3_YAML_CRD_file_to_non_strict_JSON_schema_draft_4_given_-no-strict_flag()
 {
     local expected_json_schema json_schema

--- a/tests/fixtures/expected-openshift-v4.18-route-jsonschema4.json
+++ b/tests/fixtures/expected-openshift-v4.18-route-jsonschema4.json
@@ -1,0 +1,609 @@
+{
+    "description": "A route allows developers to expose services through an HTTP(S) aware load balancing and proxy\nlayer via a public DNS entry. The route may further specify TLS options and a certificate, or\nspecify a public CNAME that the router should also accept for HTTP and HTTPS traffic. An\nadministrator typically configures their router to be visible outside the cluster firewall, and\nmay also add additional security, caching, or traffic controls on the service content. Routers\nusually talk directly to the service endpoints.\n\nOnce a route is created, the `host` field may not be changed. Generally, routers use the oldest\nroute with a given host when resolving conflicts.\n\nRouters are subject to additional customization and may support additional controls via the\nannotations field.\n\nBecause administrators may configure multiple routers, the route status field is used to\nreturn information to clients about the names and states of the route under each router.\nIf a client chooses a duplicate name, for instance, the route status conditions are used\nto indicate the route cannot be chosen.\n\nTo enable HTTP/2 ALPN on a route it requires a custom\n(non-wildcard) certificate. This prevents connection coalescing by\nclients, notably web browsers. We do not support HTTP/2 ALPN on\nroutes that use the default certificate because of the risk of\nconnection re-use/coalescing. Routes that do not have their own\ncustom certificate will not be HTTP/2 ALPN-enabled on either the\nfrontend or the backend.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+    "properties": {
+        "apiVersion": {
+            "description": "APIVersion defines the versioned schema of this representation of an object.\nServers should convert recognized schemas to the latest internal value, and\nmay reject unrecognized values.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+            "type": "string"
+        },
+        "kind": {
+            "description": "Kind is a string value representing the REST resource this object represents.\nServers may infer this from the endpoint the client submits requests to.\nCannot be updated.\nIn CamelCase.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+            "type": "string"
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "spec": {
+            "allOf": [
+                {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "path": {
+                                    "maxLength": 0
+                                }
+                            }
+                        },
+                        {
+                            "properties": {
+                                "tls": {
+                                    "enum": [
+                                        null
+                                    ]
+                                }
+                            }
+                        },
+                        {
+                            "not": {
+                                "properties": {
+                                    "tls": {
+                                        "properties": {
+                                            "termination": {
+                                                "enum": [
+                                                    "passthrough"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "anyOf": [
+                        {
+                            "not": {
+                                "properties": {
+                                    "host": {
+                                        "maxLength": 0
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "not": {
+                                "properties": {
+                                    "wildcardPolicy": {
+                                        "enum": [
+                                            "Subdomain"
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "description": "spec is the desired state of the route",
+            "properties": {
+                "alternateBackends": {
+                    "description": "alternateBackends allows up to 3 additional backends to be assigned to the route.\nOnly the Service kind is allowed, and it will be defaulted to Service.\nUse the weight field in RouteTargetReference object to specify relative preference.",
+                    "items": {
+                        "description": "RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service'\nkind is allowed. Use 'weight' field to emphasize one over others.",
+                        "properties": {
+                            "kind": {
+                                "default": "Service",
+                                "description": "The kind of target that the route is referring to. Currently, only 'Service' is allowed",
+                                "enum": [
+                                    "Service",
+                                    ""
+                                ],
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "name of the service/target that is being referred to. e.g. name of the service",
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "weight": {
+                                "default": 100,
+                                "description": "weight as an integer between 0 and 256, default 100, that specifies the target's relative weight\nagainst other target reference objects. 0 suppresses requests to this backend.",
+                                "format": "int32",
+                                "maximum": 256,
+                                "minimum": 0,
+                                "type": "integer"
+                            }
+                        },
+                        "required": [
+                            "kind",
+                            "name"
+                        ],
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "maxItems": 3,
+                    "type": "array",
+                    "x-kubernetes-list-map-keys": [
+                        "name",
+                        "kind"
+                    ],
+                    "x-kubernetes-list-type": "map"
+                },
+                "host": {
+                    "description": "host is an alias/DNS that points to the service. Optional.\nIf not specified a route name will typically be automatically\nchosen.\nMust follow DNS952 subdomain conventions.",
+                    "maxLength": 253,
+                    "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$",
+                    "type": "string"
+                },
+                "httpHeaders": {
+                    "description": "httpHeaders defines policy for HTTP headers.",
+                    "properties": {
+                        "actions": {
+                            "description": "actions specifies options for modifying headers and their values.\nNote that this option only applies to cleartext HTTP connections\nand to secure HTTP connections for which the ingress controller\nterminates encryption (that is, edge-terminated or reencrypt\nconnections).  Headers cannot be modified for TLS passthrough\nconnections.\nSetting the HSTS (`Strict-Transport-Security`) header is not supported via actions.\n`Strict-Transport-Security` may only be configured using the \"haproxy.router.openshift.io/hsts_header\"\nroute annotation, and only in accordance with the policy specified in Ingress.Spec.RequiredHSTSPolicies.\nIn case of HTTP request headers, the actions specified in spec.httpHeaders.actions on the Route will be executed after\nthe actions specified in the IngressController's spec.httpHeaders.actions field.\nIn case of HTTP response headers, the actions specified in spec.httpHeaders.actions on the IngressController will be\nexecuted after the actions specified in the Route's spec.httpHeaders.actions field.\nThe headers set via this API will not appear in access logs.\nAny actions defined here are applied after any actions related to the following other fields:\ncache-control, spec.clientTLS,\nspec.httpHeaders.forwardedHeaderPolicy, spec.httpHeaders.uniqueId,\nand spec.httpHeaders.headerNameCaseAdjustments.\nThe following header names are reserved and may not be modified via this API:\nStrict-Transport-Security, Proxy, Cookie, Set-Cookie.\nNote that the total size of all net added headers *after* interpolating dynamic values\nmust not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the\nIngressController. Please refer to the documentation\nfor that API field for more details.",
+                            "properties": {
+                                "request": {
+                                    "description": "request is a list of HTTP request headers to modify.\nCurrently, actions may define to either `Set` or `Delete` headers values.\nActions defined here will modify the request headers of all requests made through a route.\nThese actions are applied to a specific Route defined within a cluster i.e. connections made through a route.\nCurrently, actions may define to either `Set` or `Delete` headers values.\nRoute actions will be executed after IngressController actions for request headers.\nActions are applied in sequence as defined in this list.\nA maximum of 20 request header actions may be configured.\nYou can use this field to specify HTTP request headers that should be set or deleted\nwhen forwarding connections from the client to your application.\nSample fetchers allowed are \"req.hdr\" and \"ssl_c_der\".\nConverters allowed are \"lower\" and \"base64\".\nExample header values: \"%[req.hdr(X-target),lower]\", \"%{+Q}[ssl_c_der,base64]\".\nAny request header configuration applied directly via a Route resource using this API\nwill override header configuration for a header of the same name applied via\nspec.httpHeaders.actions on the IngressController or route annotation.\nNote: This field cannot be used if your route uses TLS passthrough.",
+                                    "items": {
+                                        "description": "RouteHTTPHeader specifies configuration for setting or deleting an HTTP header.",
+                                        "properties": {
+                                            "action": {
+                                                "description": "action specifies actions to perform on headers, such as setting or deleting headers.",
+                                                "properties": {
+                                                    "set": {
+                                                        "description": "set defines the HTTP header that should be set: added if it doesn't exist or replaced if it does.\nThis field is required when type is Set and forbidden otherwise.",
+                                                        "properties": {
+                                                            "value": {
+                                                                "description": "value specifies a header value.\nDynamic values can be added. The value will be interpreted as an HAProxy format string as defined in\nhttp://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and\notherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.\nThe value of this field must be no more than 16384 characters in length.\nNote that the total size of all net added headers *after* interpolating dynamic values\nmust not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the\nIngressController.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "value"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type defines the type of the action to be applied on the header.\nPossible values are Set or Delete.\nSet allows you to set HTTP request and response headers.\nDelete allows you to delete HTTP request and response headers.",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Delete"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "set is required when type is Set, and forbidden otherwise",
+                                                        "rule": "has(self.type) && self.type == 'Set' ?  has(self.set) : !has(self.set)"
+                                                    }
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header\nname as defined in RFC 2616 section 4.2.\nThe name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\".\nThe following header names are reserved and may not be modified via this API:\nStrict-Transport-Security, Proxy, Cookie, Set-Cookie.\nIt must be no more than 255 characters in length.\nHeader name must be unique.",
+                                                "maxLength": 255,
+                                                "minLength": 1,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                "type": "string",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "strict-transport-security header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'strict-transport-security'"
+                                                    },
+                                                    {
+                                                        "message": "proxy header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'proxy'"
+                                                    },
+                                                    {
+                                                        "message": "cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'cookie'"
+                                                    },
+                                                    {
+                                                        "message": "set-cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'set-cookie'"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "action",
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "Either the header value provided is not in correct format or the sample fetcher/converter specified is not allowed. The dynamic header value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. Sample fetchers allowed are req.hdr, ssl_c_der. Converters allowed are lower, base64.",
+                                            "rule": "self.all(key, key.action.type == \"Delete\" || (has(key.action.set) && key.action.set.value.matches('^(?:%(?:%|(?:\\\\{[-+]?[QXE](?:,[-+]?[QXE])*\\\\})?\\\\[(?:req\\\\.hdr\\\\([0-9A-Za-z-]+\\\\)|ssl_c_der)(?:,(?:lower|base64))*\\\\])|[^%[:cntrl:]])+$')))"
+                                        }
+                                    ]
+                                },
+                                "response": {
+                                    "description": "response is a list of HTTP response headers to modify.\nCurrently, actions may define to either `Set` or `Delete` headers values.\nActions defined here will modify the response headers of all requests made through a route.\nThese actions are applied to a specific Route defined within a cluster i.e. connections made through a route.\nRoute actions will be executed before IngressController actions for response headers.\nActions are applied in sequence as defined in this list.\nA maximum of 20 response header actions may be configured.\nYou can use this field to specify HTTP response headers that should be set or deleted\nwhen forwarding responses from your application to the client.\nSample fetchers allowed are \"res.hdr\" and \"ssl_c_der\".\nConverters allowed are \"lower\" and \"base64\".\nExample header values: \"%[res.hdr(X-target),lower]\", \"%{+Q}[ssl_c_der,base64]\".\nNote: This field cannot be used if your route uses TLS passthrough.",
+                                    "items": {
+                                        "description": "RouteHTTPHeader specifies configuration for setting or deleting an HTTP header.",
+                                        "properties": {
+                                            "action": {
+                                                "description": "action specifies actions to perform on headers, such as setting or deleting headers.",
+                                                "properties": {
+                                                    "set": {
+                                                        "description": "set defines the HTTP header that should be set: added if it doesn't exist or replaced if it does.\nThis field is required when type is Set and forbidden otherwise.",
+                                                        "properties": {
+                                                            "value": {
+                                                                "description": "value specifies a header value.\nDynamic values can be added. The value will be interpreted as an HAProxy format string as defined in\nhttp://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and\notherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.\nThe value of this field must be no more than 16384 characters in length.\nNote that the total size of all net added headers *after* interpolating dynamic values\nmust not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the\nIngressController.",
+                                                                "maxLength": 16384,
+                                                                "minLength": 1,
+                                                                "type": "string"
+                                                            }
+                                                        },
+                                                        "required": [
+                                                            "value"
+                                                        ],
+                                                        "type": "object",
+                                                        "additionalProperties": false
+                                                    },
+                                                    "type": {
+                                                        "description": "type defines the type of the action to be applied on the header.\nPossible values are Set or Delete.\nSet allows you to set HTTP request and response headers.\nDelete allows you to delete HTTP request and response headers.",
+                                                        "enum": [
+                                                            "Set",
+                                                            "Delete"
+                                                        ],
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "type"
+                                                ],
+                                                "type": "object",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "set is required when type is Set, and forbidden otherwise",
+                                                        "rule": "has(self.type) && self.type == 'Set' ?  has(self.set) : !has(self.set)"
+                                                    }
+                                                ],
+                                                "additionalProperties": false
+                                            },
+                                            "name": {
+                                                "description": "name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header\nname as defined in RFC 2616 section 4.2.\nThe name must consist only of alphanumeric and the following special characters, \"-!#$%&'*+.^_`\".\nThe following header names are reserved and may not be modified via this API:\nStrict-Transport-Security, Proxy, Cookie, Set-Cookie.\nIt must be no more than 255 characters in length.\nHeader name must be unique.",
+                                                "maxLength": 255,
+                                                "minLength": 1,
+                                                "pattern": "^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$",
+                                                "type": "string",
+                                                "x-kubernetes-validations": [
+                                                    {
+                                                        "message": "strict-transport-security header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'strict-transport-security'"
+                                                    },
+                                                    {
+                                                        "message": "proxy header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'proxy'"
+                                                    },
+                                                    {
+                                                        "message": "cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'cookie'"
+                                                    },
+                                                    {
+                                                        "message": "set-cookie header may not be modified via header actions",
+                                                        "rule": "self.lowerAscii() != 'set-cookie'"
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "required": [
+                                            "action",
+                                            "name"
+                                        ],
+                                        "type": "object",
+                                        "additionalProperties": false
+                                    },
+                                    "maxItems": 20,
+                                    "type": "array",
+                                    "x-kubernetes-list-map-keys": [
+                                        "name"
+                                    ],
+                                    "x-kubernetes-list-type": "map",
+                                    "x-kubernetes-validations": [
+                                        {
+                                            "message": "Either the header value provided is not in correct format or the sample fetcher/converter specified is not allowed. The dynamic header value will be interpreted as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2. Sample fetchers allowed are res.hdr, ssl_c_der. Converters allowed are lower, base64.",
+                                            "rule": "self.all(key, key.action.type == \"Delete\" || (has(key.action.set) && key.action.set.value.matches('^(?:%(?:%|(?:\\\\{[-+]?[QXE](?:,[-+]?[QXE])*\\\\})?\\\\[(?:res\\\\.hdr\\\\([0-9A-Za-z-]+\\\\)|ssl_c_der)(?:,(?:lower|base64))*\\\\])|[^%[:cntrl:]])+$')))"
+                                        }
+                                    ]
+                                }
+                            },
+                            "type": "object",
+                            "additionalProperties": false
+                        }
+                    },
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "path": {
+                    "description": "path that the router watches for, to route traffic for to the service. Optional",
+                    "pattern": "^/",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "If specified, the port to be used by the router. Most routers will use all\nendpoints exposed by the service by default - set this value to instruct routers\nwhich port to use.",
+                    "properties": {
+                        "targetPort": {
+                            "allOf": [
+                                {
+                                    "not": {
+                                        "enum": [
+                                            0
+                                        ]
+                                    }
+                                },
+                                {
+                                    "not": {
+                                        "enum": [
+                                            ""
+                                        ]
+                                    }
+                                }
+                            ],
+                            "description": "The target port on pods selected by the service this route points to. If this is a string, it will be looked up as a named port in the target endpoints port list. Required",
+                            "x-kubernetes-int-or-string": true
+                        }
+                    },
+                    "required": [
+                        "targetPort"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "subdomain": {
+                    "description": "subdomain is a DNS subdomain that is requested within the ingress controller's\ndomain (as a subdomain). If host is set this field is ignored. An ingress\ncontroller may choose to ignore this suggested name, in which case the controller\nwill report the assigned name in the status.ingress array or refuse to admit the\nroute. If this value is set and the server does not support this field host will\nbe populated automatically. Otherwise host is left empty. The field may have\nmultiple parts separated by a dot, but not all ingress controllers may honor\nthe request. This field may not be changed after creation except by a user with\nthe update routes/custom-host permission.\n\nExample: subdomain `frontend` automatically receives the router subdomain\n`apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.",
+                    "maxLength": 253,
+                    "pattern": "^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])(\\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9]))*$",
+                    "type": "string"
+                },
+                "tls": {
+                    "allOf": [
+                        {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "caCertificate": {
+                                            "maxLength": 0
+                                        },
+                                        "certificate": {
+                                            "maxLength": 0
+                                        },
+                                        "destinationCACertificate": {
+                                            "maxLength": 0
+                                        },
+                                        "key": {
+                                            "maxLength": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "not": {
+                                        "properties": {
+                                            "termination": {
+                                                "enum": [
+                                                    "passthrough"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "anyOf": [
+                                {
+                                    "properties": {
+                                        "destinationCACertificate": {
+                                            "maxLength": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "not": {
+                                        "properties": {
+                                            "termination": {
+                                                "enum": [
+                                                    "edge"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "description": "The tls field provides the ability to configure certificates and termination for the route.",
+                    "properties": {
+                        "caCertificate": {
+                            "description": "caCertificate provides the cert authority certificate contents",
+                            "type": "string"
+                        },
+                        "certificate": {
+                            "description": "certificate provides certificate contents. This should be a single serving certificate, not a certificate\nchain. Do not include a CA certificate.",
+                            "type": "string"
+                        },
+                        "destinationCACertificate": {
+                            "description": "destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt\ntermination this file should be provided in order to have routers use it for health checks on the secure connection.\nIf this field is not specified, the router may provide its own destination CA and perform hostname validation using\nthe short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically\nverify.",
+                            "type": "string"
+                        },
+                        "insecureEdgeTerminationPolicy": {
+                            "description": "insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While\neach router may make its own decisions on which ports to expose, this is normally port 80.\n\nIf a route does not specify insecureEdgeTerminationPolicy, then the default behavior is \"None\".\n\n* Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only).\n\n* None - no traffic is allowed on the insecure port (default).\n\n* Redirect - clients are redirected to the secure port.",
+                            "enum": [
+                                "Allow",
+                                "None",
+                                "Redirect",
+                                ""
+                            ],
+                            "type": "string"
+                        },
+                        "key": {
+                            "description": "key provides key file contents",
+                            "type": "string"
+                        },
+                        "termination": {
+                            "description": "termination indicates termination type.\n\n* edge - TLS termination is done by the router and http is used to communicate with the backend (default)\n* passthrough - Traffic is sent straight to the destination without the router providing TLS termination\n* reencrypt - TLS termination is done by the router and https is used to communicate with the backend\n\nNote: passthrough termination is incompatible with httpHeader actions",
+                            "enum": [
+                                "edge",
+                                "reencrypt",
+                                "passthrough"
+                            ],
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "termination"
+                    ],
+                    "type": "object",
+                    "x-kubernetes-validations": [
+                        {
+                            "message": "cannot have both spec.tls.termination: passthrough and spec.tls.insecureEdgeTerminationPolicy: Allow",
+                            "rule": "has(self.termination) && has(self.insecureEdgeTerminationPolicy) ? !((self.termination=='passthrough') && (self.insecureEdgeTerminationPolicy=='Allow')) : true"
+                        }
+                    ],
+                    "additionalProperties": false
+                },
+                "to": {
+                    "description": "to is an object the route should use as the primary backend. Only the Service kind\nis allowed, and it will be defaulted to Service. If the weight field (0-256 default 100)\nis set to zero, no traffic will be sent to this backend.",
+                    "properties": {
+                        "kind": {
+                            "default": "Service",
+                            "description": "The kind of target that the route is referring to. Currently, only 'Service' is allowed",
+                            "enum": [
+                                "Service",
+                                ""
+                            ],
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "name of the service/target that is being referred to. e.g. name of the service",
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        "weight": {
+                            "default": 100,
+                            "description": "weight as an integer between 0 and 256, default 100, that specifies the target's relative weight\nagainst other target reference objects. 0 suppresses requests to this backend.",
+                            "format": "int32",
+                            "maximum": 256,
+                            "minimum": 0,
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "kind",
+                        "name"
+                    ],
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "wildcardPolicy": {
+                    "default": "None",
+                    "description": "Wildcard policy if any for the route.\nCurrently only 'Subdomain' or 'None' is allowed.",
+                    "enum": [
+                        "None",
+                        "Subdomain",
+                        ""
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "to"
+            ],
+            "type": "object",
+            "x-kubernetes-validations": [
+                {
+                    "message": "header actions are not permitted when tls termination is passthrough.",
+                    "rule": "!has(self.tls) || self.tls.termination != 'passthrough' || !has(self.httpHeaders)"
+                }
+            ],
+            "additionalProperties": false
+        },
+        "status": {
+            "description": "status is the current state of the route",
+            "properties": {
+                "ingress": {
+                    "description": "ingress describes the places where the route may be exposed. The list of\ningress points may contain duplicate Host or RouterName values. Routes\nare considered live once they are `Ready`",
+                    "items": {
+                        "description": "RouteIngress holds information about the places where a route is exposed.",
+                        "properties": {
+                            "conditions": {
+                                "description": "Conditions is the state of the route, may be empty.",
+                                "items": {
+                                    "description": "RouteIngressCondition contains details for the current condition of this route on a particular\nrouter.",
+                                    "properties": {
+                                        "lastTransitionTime": {
+                                            "description": "RFC 3339 date and time when this condition last transitioned",
+                                            "format": "date-time",
+                                            "type": "string"
+                                        },
+                                        "message": {
+                                            "description": "Human readable message indicating details about last transition.",
+                                            "type": "string"
+                                        },
+                                        "reason": {
+                                            "description": "(brief) reason for the condition's last transition, and is usually a machine and human\nreadable constant",
+                                            "type": "string"
+                                        },
+                                        "status": {
+                                            "description": "Status is the status of the condition.\nCan be True, False, Unknown.",
+                                            "type": "string"
+                                        },
+                                        "type": {
+                                            "description": "Type is the type of the condition.\nCurrently only Admitted or UnservableInFutureVersions.",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "status",
+                                        "type"
+                                    ],
+                                    "type": "object",
+                                    "additionalProperties": false
+                                },
+                                "type": "array",
+                                "x-kubernetes-list-map-keys": [
+                                    "type"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                            },
+                            "host": {
+                                "description": "Host is the host string under which the route is exposed; this value is required",
+                                "type": "string"
+                            },
+                            "routerCanonicalHostname": {
+                                "description": "CanonicalHostname is the external host name for the router that can be used as a CNAME\nfor the host requested for this route. This value is optional and may not be set in all cases.",
+                                "type": "string"
+                            },
+                            "routerName": {
+                                "description": "Name is a name chosen by the router to identify itself; this value is required",
+                                "type": "string"
+                            },
+                            "wildcardPolicy": {
+                                "description": "Wildcard policy is the wildcard policy that was allowed where this route is exposed.",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object",
+                        "additionalProperties": false
+                    },
+                    "type": "array",
+                    "x-kubernetes-list-type": "atomic"
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        }
+    },
+    "required": [
+        "spec"
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/tests/fixtures/openshift-v4.18-route-v1.crd.yml
+++ b/tests/fixtures/openshift-v4.18-route-v1.crd.yml
@@ -1,0 +1,675 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/1228
+    api.openshift.io/merged-by-featuregates: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/feature-set: Default
+  name: routes.route.openshift.io
+spec:
+  group: route.openshift.io
+  names:
+    kind: Route
+    listKind: RouteList
+    plural: routes
+    singular: route
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.ingress[0].host
+      name: Host
+      type: string
+    - jsonPath: .status.ingress[0].conditions[?(@.type=="Admitted")].status
+      name: Admitted
+      type: string
+    - jsonPath: .spec.to.name
+      name: Service
+      type: string
+    - jsonPath: .spec.tls.type
+      name: TLS
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          A route allows developers to expose services through an HTTP(S) aware load balancing and proxy
+          layer via a public DNS entry. The route may further specify TLS options and a certificate, or
+          specify a public CNAME that the router should also accept for HTTP and HTTPS traffic. An
+          administrator typically configures their router to be visible outside the cluster firewall, and
+          may also add additional security, caching, or traffic controls on the service content. Routers
+          usually talk directly to the service endpoints.
+
+          Once a route is created, the `host` field may not be changed. Generally, routers use the oldest
+          route with a given host when resolving conflicts.
+
+          Routers are subject to additional customization and may support additional controls via the
+          annotations field.
+
+          Because administrators may configure multiple routers, the route status field is used to
+          return information to clients about the names and states of the route under each router.
+          If a client chooses a duplicate name, for instance, the route status conditions are used
+          to indicate the route cannot be chosen.
+
+          To enable HTTP/2 ALPN on a route it requires a custom
+          (non-wildcard) certificate. This prevents connection coalescing by
+          clients, notably web browsers. We do not support HTTP/2 ALPN on
+          routes that use the default certificate because of the risk of
+          connection re-use/coalescing. Routes that do not have their own
+          custom certificate will not be HTTP/2 ALPN-enabled on either the
+          frontend or the backend.
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            allOf:
+            - anyOf:
+              - properties:
+                  path:
+                    maxLength: 0
+              - properties:
+                  tls:
+                    enum:
+                    - null
+              - not:
+                  properties:
+                    tls:
+                      properties:
+                        termination:
+                          enum:
+                          - passthrough
+            - anyOf:
+              - not:
+                  properties:
+                    host:
+                      maxLength: 0
+              - not:
+                  properties:
+                    wildcardPolicy:
+                      enum:
+                      - Subdomain
+            description: spec is the desired state of the route
+            properties:
+              alternateBackends:
+                description: |-
+                  alternateBackends allows up to 3 additional backends to be assigned to the route.
+                  Only the Service kind is allowed, and it will be defaulted to Service.
+                  Use the weight field in RouteTargetReference object to specify relative preference.
+                items:
+                  description: |-
+                    RouteTargetReference specifies the target that resolve into endpoints. Only the 'Service'
+                    kind is allowed. Use 'weight' field to emphasize one over others.
+                  properties:
+                    kind:
+                      default: Service
+                      description: The kind of target that the route is referring
+                        to. Currently, only 'Service' is allowed
+                      enum:
+                      - Service
+                      - ""
+                      type: string
+                    name:
+                      description: name of the service/target that is being referred
+                        to. e.g. name of the service
+                      minLength: 1
+                      type: string
+                    weight:
+                      default: 100
+                      description: |-
+                        weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
+                        against other target reference objects. 0 suppresses requests to this backend.
+                      format: int32
+                      maximum: 256
+                      minimum: 0
+                      type: integer
+                  required:
+                  - kind
+                  - name
+                  type: object
+                maxItems: 3
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                - kind
+                x-kubernetes-list-type: map
+              host:
+                description: |-
+                  host is an alias/DNS that points to the service. Optional.
+                  If not specified a route name will typically be automatically
+                  chosen.
+                  Must follow DNS952 subdomain conventions.
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                type: string
+              httpHeaders:
+                description: httpHeaders defines policy for HTTP headers.
+                properties:
+                  actions:
+                    description: |-
+                      actions specifies options for modifying headers and their values.
+                      Note that this option only applies to cleartext HTTP connections
+                      and to secure HTTP connections for which the ingress controller
+                      terminates encryption (that is, edge-terminated or reencrypt
+                      connections).  Headers cannot be modified for TLS passthrough
+                      connections.
+                      Setting the HSTS (`Strict-Transport-Security`) header is not supported via actions.
+                      `Strict-Transport-Security` may only be configured using the "haproxy.router.openshift.io/hsts_header"
+                      route annotation, and only in accordance with the policy specified in Ingress.Spec.RequiredHSTSPolicies.
+                      In case of HTTP request headers, the actions specified in spec.httpHeaders.actions on the Route will be executed after
+                      the actions specified in the IngressController's spec.httpHeaders.actions field.
+                      In case of HTTP response headers, the actions specified in spec.httpHeaders.actions on the IngressController will be
+                      executed after the actions specified in the Route's spec.httpHeaders.actions field.
+                      The headers set via this API will not appear in access logs.
+                      Any actions defined here are applied after any actions related to the following other fields:
+                      cache-control, spec.clientTLS,
+                      spec.httpHeaders.forwardedHeaderPolicy, spec.httpHeaders.uniqueId,
+                      and spec.httpHeaders.headerNameCaseAdjustments.
+                      The following header names are reserved and may not be modified via this API:
+                      Strict-Transport-Security, Proxy, Cookie, Set-Cookie.
+                      Note that the total size of all net added headers *after* interpolating dynamic values
+                      must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the
+                      IngressController. Please refer to the documentation
+                      for that API field for more details.
+                    properties:
+                      request:
+                        description: |-
+                          request is a list of HTTP request headers to modify.
+                          Currently, actions may define to either `Set` or `Delete` headers values.
+                          Actions defined here will modify the request headers of all requests made through a route.
+                          These actions are applied to a specific Route defined within a cluster i.e. connections made through a route.
+                          Currently, actions may define to either `Set` or `Delete` headers values.
+                          Route actions will be executed after IngressController actions for request headers.
+                          Actions are applied in sequence as defined in this list.
+                          A maximum of 20 request header actions may be configured.
+                          You can use this field to specify HTTP request headers that should be set or deleted
+                          when forwarding connections from the client to your application.
+                          Sample fetchers allowed are "req.hdr" and "ssl_c_der".
+                          Converters allowed are "lower" and "base64".
+                          Example header values: "%[req.hdr(X-target),lower]", "%{+Q}[ssl_c_der,base64]".
+                          Any request header configuration applied directly via a Route resource using this API
+                          will override header configuration for a header of the same name applied via
+                          spec.httpHeaders.actions on the IngressController or route annotation.
+                          Note: This field cannot be used if your route uses TLS passthrough.
+                        items:
+                          description: RouteHTTPHeader specifies configuration for
+                            setting or deleting an HTTP header.
+                          properties:
+                            action:
+                              description: action specifies actions to perform on
+                                headers, such as setting or deleting headers.
+                              properties:
+                                set:
+                                  description: |-
+                                    set defines the HTTP header that should be set: added if it doesn't exist or replaced if it does.
+                                    This field is required when type is Set and forbidden otherwise.
+                                  properties:
+                                    value:
+                                      description: |-
+                                        value specifies a header value.
+                                        Dynamic values can be added. The value will be interpreted as an HAProxy format string as defined in
+                                        http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and
+                                        otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                                        The value of this field must be no more than 16384 characters in length.
+                                        Note that the total size of all net added headers *after* interpolating dynamic values
+                                        must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the
+                                        IngressController.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                type:
+                                  description: |-
+                                    type defines the type of the action to be applied on the header.
+                                    Possible values are Set or Delete.
+                                    Set allows you to set HTTP request and response headers.
+                                    Delete allows you to delete HTTP request and response headers.
+                                  enum:
+                                  - Set
+                                  - Delete
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: set is required when type is Set, and forbidden
+                                  otherwise
+                                rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set)
+                                  : !has(self.set)'
+                            name:
+                              description: |-
+                                name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header
+                                name as defined in RFC 2616 section 4.2.
+                                The name must consist only of alphanumeric and the following special characters, "-!#$%&'*+.^_`".
+                                The following header names are reserved and may not be modified via this API:
+                                Strict-Transport-Security, Proxy, Cookie, Set-Cookie.
+                                It must be no more than 255 characters in length.
+                                Header name must be unique.
+                              maxLength: 255
+                              minLength: 1
+                              pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
+                              type: string
+                              x-kubernetes-validations:
+                              - message: strict-transport-security header may not
+                                  be modified via header actions
+                                rule: self.lowerAscii() != 'strict-transport-security'
+                              - message: proxy header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'proxy'
+                              - message: cookie header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'cookie'
+                              - message: set-cookie header may not be modified via
+                                  header actions
+                                rule: self.lowerAscii() != 'set-cookie'
+                          required:
+                          - action
+                          - name
+                          type: object
+                        maxItems: 20
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Either the header value provided is not in correct
+                            format or the sample fetcher/converter specified is not
+                            allowed. The dynamic header value will be interpreted
+                            as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                            and may use HAProxy's %[] syntax and otherwise must be
+                            a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                            Sample fetchers allowed are req.hdr, ssl_c_der. Converters
+                            allowed are lower, base64.
+                          rule: self.all(key, key.action.type == "Delete" || (has(key.action.set)
+                            && key.action.set.value.matches('^(?:%(?:%|(?:\\{[-+]?[QXE](?:,[-+]?[QXE])*\\})?\\[(?:req\\.hdr\\([0-9A-Za-z-]+\\)|ssl_c_der)(?:,(?:lower|base64))*\\])|[^%[:cntrl:]])+$')))
+                      response:
+                        description: |-
+                          response is a list of HTTP response headers to modify.
+                          Currently, actions may define to either `Set` or `Delete` headers values.
+                          Actions defined here will modify the response headers of all requests made through a route.
+                          These actions are applied to a specific Route defined within a cluster i.e. connections made through a route.
+                          Route actions will be executed before IngressController actions for response headers.
+                          Actions are applied in sequence as defined in this list.
+                          A maximum of 20 response header actions may be configured.
+                          You can use this field to specify HTTP response headers that should be set or deleted
+                          when forwarding responses from your application to the client.
+                          Sample fetchers allowed are "res.hdr" and "ssl_c_der".
+                          Converters allowed are "lower" and "base64".
+                          Example header values: "%[res.hdr(X-target),lower]", "%{+Q}[ssl_c_der,base64]".
+                          Note: This field cannot be used if your route uses TLS passthrough.
+                        items:
+                          description: RouteHTTPHeader specifies configuration for
+                            setting or deleting an HTTP header.
+                          properties:
+                            action:
+                              description: action specifies actions to perform on
+                                headers, such as setting or deleting headers.
+                              properties:
+                                set:
+                                  description: |-
+                                    set defines the HTTP header that should be set: added if it doesn't exist or replaced if it does.
+                                    This field is required when type is Set and forbidden otherwise.
+                                  properties:
+                                    value:
+                                      description: |-
+                                        value specifies a header value.
+                                        Dynamic values can be added. The value will be interpreted as an HAProxy format string as defined in
+                                        http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6 and may use HAProxy's %[] syntax and
+                                        otherwise must be a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                                        The value of this field must be no more than 16384 characters in length.
+                                        Note that the total size of all net added headers *after* interpolating dynamic values
+                                        must not exceed the value of spec.tuningOptions.headerBufferMaxRewriteBytes on the
+                                        IngressController.
+                                      maxLength: 16384
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - value
+                                  type: object
+                                type:
+                                  description: |-
+                                    type defines the type of the action to be applied on the header.
+                                    Possible values are Set or Delete.
+                                    Set allows you to set HTTP request and response headers.
+                                    Delete allows you to delete HTTP request and response headers.
+                                  enum:
+                                  - Set
+                                  - Delete
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: set is required when type is Set, and forbidden
+                                  otherwise
+                                rule: 'has(self.type) && self.type == ''Set'' ?  has(self.set)
+                                  : !has(self.set)'
+                            name:
+                              description: |-
+                                name specifies the name of a header on which to perform an action. Its value must be a valid HTTP header
+                                name as defined in RFC 2616 section 4.2.
+                                The name must consist only of alphanumeric and the following special characters, "-!#$%&'*+.^_`".
+                                The following header names are reserved and may not be modified via this API:
+                                Strict-Transport-Security, Proxy, Cookie, Set-Cookie.
+                                It must be no more than 255 characters in length.
+                                Header name must be unique.
+                              maxLength: 255
+                              minLength: 1
+                              pattern: ^[-!#$%&'*+.0-9A-Z^_`a-z|~]+$
+                              type: string
+                              x-kubernetes-validations:
+                              - message: strict-transport-security header may not
+                                  be modified via header actions
+                                rule: self.lowerAscii() != 'strict-transport-security'
+                              - message: proxy header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'proxy'
+                              - message: cookie header may not be modified via header
+                                  actions
+                                rule: self.lowerAscii() != 'cookie'
+                              - message: set-cookie header may not be modified via
+                                  header actions
+                                rule: self.lowerAscii() != 'set-cookie'
+                          required:
+                          - action
+                          - name
+                          type: object
+                        maxItems: 20
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                        x-kubernetes-validations:
+                        - message: Either the header value provided is not in correct
+                            format or the sample fetcher/converter specified is not
+                            allowed. The dynamic header value will be interpreted
+                            as an HAProxy format string as defined in http://cbonte.github.io/haproxy-dconv/2.6/configuration.html#8.2.6
+                            and may use HAProxy's %[] syntax and otherwise must be
+                            a valid HTTP header value as defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.
+                            Sample fetchers allowed are res.hdr, ssl_c_der. Converters
+                            allowed are lower, base64.
+                          rule: self.all(key, key.action.type == "Delete" || (has(key.action.set)
+                            && key.action.set.value.matches('^(?:%(?:%|(?:\\{[-+]?[QXE](?:,[-+]?[QXE])*\\})?\\[(?:res\\.hdr\\([0-9A-Za-z-]+\\)|ssl_c_der)(?:,(?:lower|base64))*\\])|[^%[:cntrl:]])+$')))
+                    type: object
+                type: object
+              path:
+                description: path that the router watches for, to route traffic for
+                  to the service. Optional
+                pattern: ^/
+                type: string
+              port:
+                description: |-
+                  If specified, the port to be used by the router. Most routers will use all
+                  endpoints exposed by the service by default - set this value to instruct routers
+                  which port to use.
+                properties:
+                  targetPort:
+                    allOf:
+                    - not:
+                        enum:
+                        - 0
+                    - not:
+                        enum:
+                        - ""
+                    anyOf: null
+                    description: The target port on pods selected by the service this
+                      route points to. If this is a string, it will be looked up as
+                      a named port in the target endpoints port list. Required
+                    x-kubernetes-int-or-string: true
+                required:
+                - targetPort
+                type: object
+              subdomain:
+                description: |-
+                  subdomain is a DNS subdomain that is requested within the ingress controller's
+                  domain (as a subdomain). If host is set this field is ignored. An ingress
+                  controller may choose to ignore this suggested name, in which case the controller
+                  will report the assigned name in the status.ingress array or refuse to admit the
+                  route. If this value is set and the server does not support this field host will
+                  be populated automatically. Otherwise host is left empty. The field may have
+                  multiple parts separated by a dot, but not all ingress controllers may honor
+                  the request. This field may not be changed after creation except by a user with
+                  the update routes/custom-host permission.
+
+                  Example: subdomain `frontend` automatically receives the router subdomain
+                  `apps.mycluster.com` to have a full hostname `frontend.apps.mycluster.com`.
+                maxLength: 253
+                pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
+                type: string
+              tls:
+                allOf:
+                - anyOf:
+                  - properties:
+                      caCertificate:
+                        maxLength: 0
+                      certificate:
+                        maxLength: 0
+                      destinationCACertificate:
+                        maxLength: 0
+                      key:
+                        maxLength: 0
+                  - not:
+                      properties:
+                        termination:
+                          enum:
+                          - passthrough
+                - anyOf:
+                  - properties:
+                      destinationCACertificate:
+                        maxLength: 0
+                  - not:
+                      properties:
+                        termination:
+                          enum:
+                          - edge
+                description: The tls field provides the ability to configure certificates
+                  and termination for the route.
+                properties:
+                  caCertificate:
+                    description: caCertificate provides the cert authority certificate
+                      contents
+                    type: string
+                  certificate:
+                    description: |-
+                      certificate provides certificate contents. This should be a single serving certificate, not a certificate
+                      chain. Do not include a CA certificate.
+                    type: string
+                  destinationCACertificate:
+                    description: |-
+                      destinationCACertificate provides the contents of the ca certificate of the final destination.  When using reencrypt
+                      termination this file should be provided in order to have routers use it for health checks on the secure connection.
+                      If this field is not specified, the router may provide its own destination CA and perform hostname validation using
+                      the short service name (service.namespace.svc), which allows infrastructure generated certificates to automatically
+                      verify.
+                    type: string
+                  insecureEdgeTerminationPolicy:
+                    description: |-
+                      insecureEdgeTerminationPolicy indicates the desired behavior for insecure connections to a route. While
+                      each router may make its own decisions on which ports to expose, this is normally port 80.
+
+                      If a route does not specify insecureEdgeTerminationPolicy, then the default behavior is "None".
+
+                      * Allow - traffic is sent to the server on the insecure port (edge/reencrypt terminations only).
+
+                      * None - no traffic is allowed on the insecure port (default).
+
+                      * Redirect - clients are redirected to the secure port.
+                    enum:
+                    - Allow
+                    - None
+                    - Redirect
+                    - ""
+                    type: string
+                  key:
+                    description: key provides key file contents
+                    type: string
+                  termination:
+                    description: |-
+                      termination indicates termination type.
+
+                      * edge - TLS termination is done by the router and http is used to communicate with the backend (default)
+                      * passthrough - Traffic is sent straight to the destination without the router providing TLS termination
+                      * reencrypt - TLS termination is done by the router and https is used to communicate with the backend
+
+                      Note: passthrough termination is incompatible with httpHeader actions
+                    enum:
+                    - edge
+                    - reencrypt
+                    - passthrough
+                    type: string
+                required:
+                - termination
+                type: object
+                x-kubernetes-validations:
+                - message: 'cannot have both spec.tls.termination: passthrough and
+                    spec.tls.insecureEdgeTerminationPolicy: Allow'
+                  rule: 'has(self.termination) && has(self.insecureEdgeTerminationPolicy)
+                    ? !((self.termination==''passthrough'') && (self.insecureEdgeTerminationPolicy==''Allow''))
+                    : true'
+              to:
+                description: |-
+                  to is an object the route should use as the primary backend. Only the Service kind
+                  is allowed, and it will be defaulted to Service. If the weight field (0-256 default 100)
+                  is set to zero, no traffic will be sent to this backend.
+                properties:
+                  kind:
+                    default: Service
+                    description: The kind of target that the route is referring to.
+                      Currently, only 'Service' is allowed
+                    enum:
+                    - Service
+                    - ""
+                    type: string
+                  name:
+                    description: name of the service/target that is being referred
+                      to. e.g. name of the service
+                    minLength: 1
+                    type: string
+                  weight:
+                    default: 100
+                    description: |-
+                      weight as an integer between 0 and 256, default 100, that specifies the target's relative weight
+                      against other target reference objects. 0 suppresses requests to this backend.
+                    format: int32
+                    maximum: 256
+                    minimum: 0
+                    type: integer
+                required:
+                - kind
+                - name
+                type: object
+              wildcardPolicy:
+                default: None
+                description: |-
+                  Wildcard policy if any for the route.
+                  Currently only 'Subdomain' or 'None' is allowed.
+                enum:
+                - None
+                - Subdomain
+                - ""
+                type: string
+            required:
+            - to
+            type: object
+            x-kubernetes-validations:
+            - message: header actions are not permitted when tls termination is passthrough.
+              rule: '!has(self.tls) || self.tls.termination != ''passthrough'' ||
+                !has(self.httpHeaders)'
+          status:
+            description: status is the current state of the route
+            properties:
+              ingress:
+                description: |-
+                  ingress describes the places where the route may be exposed. The list of
+                  ingress points may contain duplicate Host or RouterName values. Routes
+                  are considered live once they are `Ready`
+                items:
+                  description: RouteIngress holds information about the places where
+                    a route is exposed.
+                  properties:
+                    conditions:
+                      description: Conditions is the state of the route, may be empty.
+                      items:
+                        description: |-
+                          RouteIngressCondition contains details for the current condition of this route on a particular
+                          router.
+                        properties:
+                          lastTransitionTime:
+                            description: RFC 3339 date and time when this condition
+                              last transitioned
+                            format: date-time
+                            type: string
+                          message:
+                            description: Human readable message indicating details
+                              about last transition.
+                            type: string
+                          reason:
+                            description: |-
+                              (brief) reason for the condition's last transition, and is usually a machine and human
+                              readable constant
+                            type: string
+                          status:
+                            description: |-
+                              Status is the status of the condition.
+                              Can be True, False, Unknown.
+                            type: string
+                          type:
+                            description: |-
+                              Type is the type of the condition.
+                              Currently only Admitted or UnservableInFutureVersions.
+                            type: string
+                        required:
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    host:
+                      description: Host is the host string under which the route is
+                        exposed; this value is required
+                      type: string
+                    routerCanonicalHostname:
+                      description: |-
+                        CanonicalHostname is the external host name for the router that can be used as a CNAME
+                        for the host requested for this route. This value is optional and may not be set in all cases.
+                      type: string
+                    routerName:
+                      description: Name is a name chosen by the router to identify
+                        itself; this value is required
+                      type: string
+                    wildcardPolicy:
+                      description: Wildcard policy is the wildcard policy that was
+                        allowed where this route is exposed.
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Otherwise, this leads to yaml validation errors with complex crds such as the openshift v4.18 route object.